### PR TITLE
Fixing and improving build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: "Build App"
 
 on:
   pull_request:
+    paths:
+      - "app/src/**"
     types:
       - "opened"
       - "reopened"
@@ -10,11 +12,7 @@ on:
 jobs:
   build:
     permissions:
-      # Required to upload/save artifact, otherwise you'll get
-      # "Error: Resource not accessible by integration"
       contents: write
-      # Required to post comment, otherwise you'll get
-      # "Error: Resource not accessible by integration"
       pull-requests: write
     name: "build"
     runs-on: "ubuntu-latest"
@@ -27,19 +25,18 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
+          cache: "gradle"
 
       - name: "Setup Gradle"
         uses: "gradle/gradle-build-action@v2"
         with:
-          gradle-home-cache-cleanup: true
           generate-job-summary: false
 
       - name: "Build APK"
         run: "bash gradlew assembleRelease --no-daemon"
 
-      - name: "Comment apk url file on PR"
-        uses: "gavv/pull-request-artifacts@v1.1.0"
+      - name: "Upload artifacts"
+        uses: "actions/upload-artifact@v3"
         with:
-          commit: "${{ github.event.pull_request.head.sha }}"
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          artifacts: "app/build/outputs/apk/release/app-release.apk"
+          name: "app-release"
+          path: "app/build/outputs/apk/release/app-release.apk"


### PR DESCRIPTION
## The Problem

In pull request #18, a new workflow was added to build the APK when a pull request is created. But it has a `bug`.

When the workflow runs successfully, it creates a comment on the pull request with the download URL. However, this action of uploading the artifact and commenting adds the newly built APK to the master branch.

![Screenshot_20230725_101625_Chrome](https://github.com/przemarbor/RUTMath/assets/91166070/e629ad4e-49eb-4aaa-93b5-0060dfcf4d54)

![Screenshot_20230725_101804_Chrome](https://github.com/przemarbor/RUTMath/assets/91166070/fb396c0a-6b6a-4875-97c2-0d378cb8663c)

This was my mistake when creating the workflow; I didn't pay attention to the `gavv/pull-request-artifacts` documentation.

## Solution
- I changed the step `gavv/pull-request-artifacts` to `actions/upload-artifact`. Now the file will not be uploaded to the master branch, and it will also not add the comment to the pull request.
- Now only modified/added files in the path `app/src/**` trigger the build job.

## Where does the app upload go?
At the bottom of the workflow summary page, there is a dedicated section for artifacts. Here's a screenshot of something you might see:

![jWH7wir2Ee6dQAJCrBEAAg](https://github.com/przemarbor/RUTMath/assets/91166070/044bfc13-6742-4ad1-92dd-895e59942134)